### PR TITLE
Fix missing null terminator in tools/mkfs.c

### DIFF
--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -251,7 +251,12 @@ main(int32_t argc, char *argv[])
 			name = argv[i];
 			ino = rootino;
 		}
-		strncpy(de.d_name, name, DIRSIZ);
+
+		if (strlen(name) > DIRSIZ - 1) {
+			fprintf(stderr, "WARNING: filename being truncated: '%s'\n", name);
+		}
+		strncpy(de.d_name, name, DIRSIZ - 1);
+		de.d_name[DIRSIZ - 1] = '\0';
 
 		inum = ialloc(S_IFREG | S_IAUSR);
 


### PR DESCRIPTION
strncpy does not write a null terminator if the src string is longer than the dst size. If a user passed a filename that was longer than DIRSIZ-1, then we would silently write a non-null-terminated string to `de.d_name`.

This bug triggers a warning on GCC 14.2.1:

```
tools/mkfs.c: In function ‘main’:
tools/mkfs.c:254:17: error: ‘__builtin_strncpy’ specified bound 254 equals destination size [-Werror=stringop-truncation]
  254 |                 strncpy(de.d_name, name, DIRSIZ);
      |                 ^
```